### PR TITLE
Unified the build env representation!

### DIFF
--- a/gen/src/composer.rs
+++ b/gen/src/composer.rs
@@ -56,7 +56,7 @@ impl InputAddress {
     }
 
     fn input_address_or<F: FnOnce(&str) -> &str> (input: &str, f: F) -> String {
-        
+       "" .to_string()
     }
 
 }
@@ -100,23 +100,23 @@ impl<'a> Composer<'a>{
         }
     }
 
-    fn k8s_status_values_path_from_torb_input(
-        &self,
-        torb_input: &String,
-    ) -> String {
-        let input = torb_input.split(".").last().unwrap();
+    // fn k8s_status_values_path_from_torb_input(
+    //     &self,
+    //     torb_input: &String,
+    // ) -> String {
+    //     let input = torb_input.split(".").last().unwrap();
 
-        let (kube_value, _) = output_node
-            .inputs
-            .get(input)
-            .expect("Unable to map input from output node. Key does not exist.");
+    //     let (kube_value, _) = output_node
+    //         .inputs
+    //         .get(input)
+    //         .expect("Unable to map input from output node. Key does not exist.");
 
-        let formatted_name = kebab_to_snake_case(&self.release_name);
+    //     let formatted_name = kebab_to_snake_case(&self.release_name);
 
-        let block_name = format!("{}_{}", formatted_name, &output_node.name);
+    //     let block_name = format!("{}_{}", formatted_name, &output_node.name);
 
-        format!("{}.status.0.values.{}", block_name, kube_value)
-    }
+    //     format!("{}.status.0.values.{}", block_name, kube_value)
+    // }
 
     pub fn compose(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         println!("Composing build environment...");
@@ -292,19 +292,19 @@ impl<'a> Composer<'a>{
     fn parse_input(self, input: &str) {
     }
 
-    fn create_input_blocks(&self, node: &ArtifactNodeRepr) -> Vec<Block> {
-        let mut input_blocks = Vec::new();
-        for (name, (spec, value)) in node.inputs.iter() {
-            let value = self.k8s_status_values_path_from_torb_input(value);
-            let block = Block::builder("set")
-                .add_attribute((spec, RawExpression::new(value.clone())))
-                .build();
+    // fn create_input_blocks(&self, node: &ArtifactNodeRepr) -> Vec<Block> {
+    //     let mut input_blocks = Vec::new();
+    //     for (name, (spec, value)) in node.inputs.iter() {
+    //         let value = self.k8s_status_values_path_from_torb_input(value);
+    //         let block = Block::builder("set")
+    //             .add_attribute((spec, RawExpression::new(value.clone())))
+    //             .build();
 
-            input_blocks.push(block);
-        }
+    //         input_blocks.push(block);
+    //     }
 
-        input_blocks
-    }
+    //     input_blocks
+    // }
 
     fn add_to_main_struct(
         &mut self,
@@ -320,7 +320,7 @@ impl<'a> Composer<'a>{
             .to_string()
             .replace("_", "-");
 
-        let inputs = self.create_input_blocks(node);
+        // let inputs = self.create_input_blocks(node);
 
         let mut attributes = vec![
             ("source", source),


### PR DESCRIPTION
In this case even though originally the two structs served different purposes, with ArtifactNodeRepr to be more of a clean presentation layer that would serialize into the build artifact and DependencyNode to be the deserialized representation for the lower level service and project yamls, ultimately they differed very little and for presentation purposes we can rely on Serde's attributes to skip or alias fields, removing the need for a purely presentational struct. 


Settled on ArtifactNodeRepr with 3 additional fields taken from the now removed DependencyNode.

The 3 fields are:

stack_graph
input_spec
dependency_names (previously dependencies)


Renamed fields on ArtifactNodeRepr

inputs -> mapped_inputs

