### PR TITLE
Add multi-arch

### DIFF
--- a/gen/src/builder.rs
+++ b/gen/src/builder.rs
@@ -21,14 +21,16 @@ pub struct StackBuilder<'a> {
     artifact: &'a ArtifactRepr,
     built: HashSet<String>,
     dryrun: bool,
+    build_platforms: String
 }
 
 impl<'a> StackBuilder<'a> {
-    pub fn new(artifact: &'a ArtifactRepr, dryrun: bool) -> StackBuilder<'a> {
+    pub fn new(artifact: &'a ArtifactRepr, build_platforms: String, dryrun: bool) -> StackBuilder<'a> {
         StackBuilder {
             artifact: artifact,
             built: HashSet::new(),
             dryrun: dryrun,
+            build_platforms: build_platforms
         }
     }
 
@@ -77,11 +79,11 @@ impl<'a> StackBuilder<'a> {
 
         let mut commands = vec![CommandConfig::new(
             "docker",
-            vec!["build", "-t", &label, ".", "-f", &dockerfile],
+            vec!["buildx", "build", "--platform", &self.build_platforms, "-t", &label, ".", "-f", &dockerfile],
             Some(&dockerfile_dir.to_str().unwrap()),
         )];
 
-        if registry != "" {
+        if registry != "local" {
             commands.push(CommandConfig::new(
                 "docker",
                 vec!["push", &label],


### PR DESCRIPTION
Closes #2 

Note @kallsyms, in addition to my changes, that to enable multi-arch on docker desktop for mac (and maybe other platforms?) you must create a custom builder and switch to it. 

" docker buildx create --name mybuilder --use"

https://cloudolife.com/2022/03/05/Infrastructure-as-Code-IaC/Container/Docker/Docker-buildx-support-multiple-architectures-images/

I plan to add a warning in another PR.

